### PR TITLE
Remove useless toggleLights sound code

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/ToggleLightsProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/ToggleLightsProcessor.cs
@@ -9,12 +9,8 @@ namespace NitroxClient.Communication.Packets.Processors;
 
 public class ToggleLightsProcessor : ClientPacketProcessor<NitroxModel.Packets.ToggleLights>
 {
-    private readonly FMODWhitelist fmodWhitelist;
-
-    public ToggleLightsProcessor(FMODWhitelist fmodWhitelist)
-    {
-        this.fmodWhitelist = fmodWhitelist;
-    }
+    public ToggleLightsProcessor()
+    { }
 
     public override void Process(NitroxModel.Packets.ToggleLights packet)
     {
@@ -29,26 +25,7 @@ public class ToggleLightsProcessor : ClientPacketProcessor<NitroxModel.Packets.T
         using (PacketSuppressor<NitroxModel.Packets.ToggleLights>.Suppress())
         using (FMODSystem.SuppressSendingSounds())
         {
-            using (FMODSystem.SuppressSubnauticaSounds())
-            {
-                toggleLights.SetLightsActive(packet.IsOn);
-            }
-
-            FMODAsset soundAsset;
-
-            if (packet.IsOn)
-            {
-                soundAsset = toggleLights.lightsOnSound ? toggleLights.lightsOnSound.asset : toggleLights.onSound;
-            }
-            else
-            {
-                soundAsset = toggleLights.lightsOffSound ? toggleLights.lightsOffSound.asset : toggleLights.offSound;
-            }
-
-            if (soundAsset && fmodWhitelist.TryGetSoundData(soundAsset.path, out SoundData soundData))
-            {
-                FMODEmitterController.PlayEventOneShot(soundAsset, soundData.Radius, toggleLights.transform.position);
-            }
+            toggleLights.SetLightsActive(packet.IsOn);
         }
     }
 }

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/SeamothMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/SeamothMetadataProcessor.cs
@@ -11,12 +11,8 @@ namespace NitroxClient.GameLogic.Spawning.Metadata.Processor;
 
 public class SeamothMetadataProcessor : VehicleMetadataProcessor<SeamothMetadata>
 {
-    private readonly FMODWhitelist fmodWhitelist;
-
-    public SeamothMetadataProcessor(LiveMixinManager liveMixinManager, FMODWhitelist fmodWhitelist) : base(liveMixinManager)
-    {
-        this.fmodWhitelist = fmodWhitelist;
-    }
+    public SeamothMetadataProcessor(LiveMixinManager liveMixinManager) : base(liveMixinManager)
+    { }
 
     public override void ProcessMetadata(GameObject gameObject, SeamothMetadata metadata)
     {
@@ -50,29 +46,9 @@ public class SeamothMetadataProcessor : VehicleMetadataProcessor<SeamothMetadata
             return;
         }
 
-        // In the future, maybe do a patch for all ToggleLights.SetLightsActive() to handle all cases of lights toggling (i.e. powercell being inserted, etc.)
         using (FMODSystem.SuppressSendingSounds())
         {
-            FMODAsset soundAsset;
-
-            using (FMODSystem.SuppressSubnauticaSounds())
-            {
-                toggleLights.SetLightsActive(lightsOn);
-            }
-
-            if (lightsOn)
-            {
-                soundAsset = toggleLights.lightsOnSound ? toggleLights.lightsOnSound.asset : toggleLights.onSound;
-            }
-            else
-            {
-                soundAsset = toggleLights.lightsOffSound ? toggleLights.lightsOffSound.asset : toggleLights.offSound;
-            }
-
-            if (soundAsset && fmodWhitelist.TryGetSoundData(soundAsset.path, out SoundData soundData))
-            {
-                FMODEmitterController.PlayEventOneShot(soundAsset, soundData.Radius, toggleLights.transform.position);
-            }
+            seamoth.toggleLights.SetLightsActive(lightsOn);
         }
     }
 }


### PR DESCRIPTION
Now that there is a patch for the toggleLights sounds, we can remove the now-useless toggleLights sound handling code for the SeamothMetada and ToggleLights processors. This also gets rid of a duplicate light sound that can come from the Seamoth when you replace its power cell.

Tested these changes in-game and everything still seems to work as intended.